### PR TITLE
Removing @jkovalsky from list of default bug assignees.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve Northwind Traders Complete Accounting for Truckers
 title: "BUG: "
 labels: "bug"
-assignees: "SeanCarrick, jkovalsky"
+assignees: "SeanCarrick"
 
 ---
 


### PR DESCRIPTION
I do not think that having both of us as default assignees is a good idea. Quite opposite I think it's better to not have anyone as assignee and only set this field when the person agrees to take the issue over and starts to work on it.